### PR TITLE
Read /proc/net/arp instead of running `arp` command

### DIFF
--- a/common.py
+++ b/common.py
@@ -9,11 +9,11 @@ from struct import unpack
 from time import localtime
 
 def find_arp(INSTRUMENT_OUI):
-    result = subprocess.check_output("arp -n | grep '%s' | awk '{print $1}'" % (INSTRUMENT_OUI), shell=True)
-    result_string = result.decode("utf-8").strip()
-    if not result_string:
+    ipaddr_bytes = subprocess.check_output("arp -n | grep '%s' | awk '{print $1}'" % (INSTRUMENT_OUI), shell=True)
+    ipaddr_str = ipaddr_bytes.decode("utf-8").strip()
+    if not ipaddr_str:
         return None
-    return result_string
+    return ipaddr_str
 
 def instrument_ping(instrument_ip):
     if system("ping -c 1 %s > /dev/null" % (instrument_ip)) == 0:

--- a/common.py
+++ b/common.py
@@ -9,11 +9,14 @@ from struct import unpack
 from time import localtime
 
 def find_arp(INSTRUMENT_OUI):
-    ipaddr_bytes = subprocess.check_output("arp -n | grep '%s' | awk '{print $1}'" % (INSTRUMENT_OUI), shell=True)
-    ipaddr_str = ipaddr_bytes.decode("utf-8").strip()
-    if not ipaddr_str:
-        return None
-    return ipaddr_str
+    with open('/proc/net/arp') as f:
+        f.readline()    # Drop header line
+        for line in f:
+            words = line.split()
+            ipaddr_str, hwaddr, = words[0], words[3]
+            if hwaddr.startswith(INSTRUMENT_OUI):
+                return ipaddr_str
+    return None
 
 def instrument_ping(instrument_ip):
     if system("ping -c 1 %s > /dev/null" % (instrument_ip)) == 0:

--- a/ds1054-capture
+++ b/ds1054-capture
@@ -74,20 +74,20 @@ def print_help():
     print ("    as a CSV, PNG or BMP file with a timestamp in the file name.")
     print ()
 
-def find_arp(oui):
-    result = subprocess.check_output("arp -n | grep '%s' | awk '{print $1}'" % (oui), shell=True)
-    result_string = result.decode("utf-8").strip()
-    if not result_string:
+def find_arp_or_die(oui):
+    ipaddr_str = find_arp(oui)
+    if ipaddr_str:
+        return ipaddr_str
+    else:
         print_help()
         sys.exit("Error: Hardware address not found in ARP table, IP will have to be specified manually.")
-    return result_string
 
 if len(sys.argv) == 1:
-    IP_DS1104Z = find_arp(RIGOL_OUI)
+    IP_DS1104Z = find_arp_or_die(RIGOL_OUI)
 elif len(sys.argv) == 2:
     if sys.argv[1].lower() in ["png", "bmp", "csv"]:
         file_format = sys.argv[1].lower()
-        IP_DS1104Z = find_arp(RIGOL_OUI)
+        IP_DS1104Z = find_arp_or_die(RIGOL_OUI)
     else:
         IP_DS1104Z = sys.argv[1]
 elif len(sys.argv) == 3:

--- a/ds1054-capture
+++ b/ds1054-capture
@@ -140,9 +140,9 @@ if file_format in ["png", "bmp"]:
     print ("Receiving screen capture...")
 
     if file_format == "png":
-    	buff = command(tn, ":DISP:DATA? ON,OFF,PNG")
+        buff = command(tn, ":DISP:DATA? ON,OFF,PNG")
     else:
-    	buff = command(tn, ":DISP:DATA? ON,OFF,BMP8")
+        buff = command(tn, ":DISP:DATA? ON,OFF,BMP8")
 
     expectedBuffLen = expected_buff_bytes(buff)
     # Just in case the transfer did not complete in the expected time, read the remaining 'buff' chunks
@@ -162,7 +162,7 @@ if file_format in ["png", "bmp"]:
 
     # Write raw data to file
     with open(filename, 'wb') as f:
-    	f.write(buff)
+        f.write(buff)
     print('Saved screenshot to %s (%.1fKB)' % (filename, expectedDataLen/1024.0))
 
 # TODO: Change WAV:FORM from ASC to BYTE

--- a/e36312a-capture
+++ b/e36312a-capture
@@ -32,7 +32,7 @@ if len(sys.argv) == 1:
         print_help()
         sys.exit("Error: Hardware address not found in ARP table, IP will have to be specified manually.")
 elif len(sys.argv) == 2:
-	INSTRUMENT_IP = sys.argv[1]
+        INSTRUMENT_IP = sys.argv[1]
 else:
     print_help()
     sys.exit("Error: Wrong command line parameters.")


### PR DESCRIPTION
This increases reliability (and efficiency); see the commit messages for details. Since this PR also includes some refactoring commits, the changes will also be easier to understand and review if you look at the individual commits.